### PR TITLE
Updated FirstSolarSat contrat to fix loopholes

### DIFF
--- a/GameData/RP-1/Contracts/Early Satellites (Light)/FirstSolarSat.cfg
+++ b/GameData/RP-1/Contracts/Early Satellites (Light)/FirstSolarSat.cfg
@@ -143,7 +143,7 @@ CONTRACT_TYPE
 			minRate = -1000000
 			maxRate = 0.00001
 			completeInSequence = true
-		}
+   		}
 
 		PARAMETER
 		{
@@ -152,6 +152,16 @@ CONTRACT_TYPE
 			resource = ElectricCharge
 			minQuantity = 100
 			completeInSequence = true
-		}
+   			
+      			PARAMETER
+			{
+				name = Duration
+				type = Duration
+				duration = 2h
+				preWaitText = Check for battery level
+				waitingText = Checking for battery level
+				completionText = Battery level: Confirmed
+			}
+  		}
 	}
 }


### PR DESCRIPTION
Should fix loopholes of having disconnected batteries and hopefully should  thwart potential killed avionics cheese, requiring to stay above 100 battery for 2 hours after the 14 days orbit.

The above should not affect large solar sat with enough intake for 14 days or sputnik with small solar way of completing the contract.

Remaining tests: make sure it can be completed from Space Center?